### PR TITLE
Refator: move function Len() to llrb-stats.go

### DIFF
--- a/llrb-stats.go
+++ b/llrb-stats.go
@@ -4,6 +4,9 @@
 
 package buffer
 
+// Len returns the number of nodes in the tree.
+func (t *LLRB) Len() int { return t.count }
+
 // GetHeight() returns an item in the tree with key @key, and its height in the tree
 func (t *LLRB) GetHeight(key Item) (result Item, depth int) {
 	return t.getHeight(t.root, key)

--- a/llrb.go
+++ b/llrb.go
@@ -90,9 +90,6 @@ func (t *LLRB) Root() *Node {
 	return t.root
 }
 
-// Len returns the number of nodes in the tree.
-func (t *LLRB) Len() int { return t.count }
-
 // Has returns true if the tree contains an element whose order is the same as that of key.
 func (t *LLRB) Has(key Item) bool {
 	return t.Get(key) != nil


### PR DESCRIPTION
The length of the tree is also one of its status, it is better to put
the function into llrb-stats.go, to be consistent with other parts.

Signed-off-by: Hu Keping <hukeping@huawei.com>