### PR TITLE
Refactor ItemIterator interface

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -1,6 +1,6 @@
 package buffer
 
-type ItemIterator func(i Item) bool
+type ItemIterator func(i Item, t *LLRB) bool
 
 //func (t *Tree) Ascend(iterator ItemIterator) {
 //	t.AscendGreaterOrEqual(Inf(-1), iterator)
@@ -24,7 +24,7 @@ func (t *LLRB) ascendRange(h *Node, inf, sup Item, iterator ItemIterator) bool {
 	if !t.ascendRange(h.Left, inf, sup, iterator) {
 		return false
 	}
-	if !iterator(h.Item) {
+	if !iterator(h.Item, t) {
 		return false
 	}
 	return t.ascendRange(h.Right, inf, sup, iterator)
@@ -44,7 +44,7 @@ func (t *LLRB) ascendGreaterOrEqual(h *Node, pivot Item, iterator ItemIterator) 
 		if !t.ascendGreaterOrEqual(h.Left, pivot, iterator) {
 			return false
 		}
-		if !iterator(h.Item) {
+		if !iterator(h.Item, t) {
 			return false
 		}
 	}
@@ -62,7 +62,7 @@ func (t *LLRB) ascendLessThan(h *Node, pivot Item, iterator ItemIterator) bool {
 	if !t.ascendLessThan(h.Left, pivot, iterator) {
 		return false
 	}
-	if !iterator(h.Item) {
+	if !iterator(h.Item, t) {
 		return false
 	}
 	if less(h.Item, pivot) {
@@ -85,7 +85,7 @@ func (t *LLRB) descendLessOrEqual(h *Node, pivot Item, iterator ItemIterator) bo
 		if !t.descendLessOrEqual(h.Right, pivot, iterator) {
 			return false
 		}
-		if !iterator(h.Item) {
+		if !iterator(h.Item, t) {
 			return false
 		}
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -12,7 +12,7 @@ func TestAscendGreaterOrEqual(t *testing.T) {
 	tree.InsertNoReplace(Int(1))
 	tree.InsertNoReplace(Int(3))
 	var ary []Item
-	tree.AscendGreaterOrEqual(Int(-1), func(i Item) bool {
+	tree.AscendGreaterOrEqual(Int(-1), func(i Item, t *LLRB) bool {
 		ary = append(ary, i)
 		return true
 	})
@@ -21,7 +21,7 @@ func TestAscendGreaterOrEqual(t *testing.T) {
 		t.Errorf("expected %v but got %v", expected, ary)
 	}
 	ary = nil
-	tree.AscendGreaterOrEqual(Int(3), func(i Item) bool {
+	tree.AscendGreaterOrEqual(Int(3), func(i Item, tree *LLRB) bool {
 		ary = append(ary, i)
 		return true
 	})
@@ -30,7 +30,7 @@ func TestAscendGreaterOrEqual(t *testing.T) {
 		t.Errorf("expected %v but got %v", expected, ary)
 	}
 	ary = nil
-	tree.AscendGreaterOrEqual(Int(2), func(i Item) bool {
+	tree.AscendGreaterOrEqual(Int(2), func(i Item, tree *LLRB) bool {
 		ary = append(ary, i)
 		return true
 	})
@@ -47,7 +47,7 @@ func TestDescendLessOrEqual(t *testing.T) {
 	tree.InsertNoReplace(Int(1))
 	tree.InsertNoReplace(Int(3))
 	var ary []Item
-	tree.DescendLessOrEqual(Int(10), func(i Item) bool {
+	tree.DescendLessOrEqual(Int(10), func(i Item, tree *LLRB) bool {
 		ary = append(ary, i)
 		return true
 	})
@@ -56,7 +56,7 @@ func TestDescendLessOrEqual(t *testing.T) {
 		t.Errorf("expected %v but got %v", expected, ary)
 	}
 	ary = nil
-	tree.DescendLessOrEqual(Int(4), func(i Item) bool {
+	tree.DescendLessOrEqual(Int(4), func(i Item, tree *LLRB) bool {
 		ary = append(ary, i)
 		return true
 	})
@@ -65,7 +65,7 @@ func TestDescendLessOrEqual(t *testing.T) {
 		t.Errorf("expected %v but got %v", expected, ary)
 	}
 	ary = nil
-	tree.DescendLessOrEqual(Int(5), func(i Item) bool {
+	tree.DescendLessOrEqual(Int(5), func(i Item, tree *LLRB) bool {
 		ary = append(ary, i)
 		return true
 	})

--- a/llrb_test.go
+++ b/llrb_test.go
@@ -45,7 +45,7 @@ func TestReverseInsertOrder(t *testing.T) {
 		tree.ReplaceOrInsert(Int(n - i))
 	}
 	i := 0
-	tree.AscendGreaterOrEqual(Int(0), func(item Item) bool {
+	tree.AscendGreaterOrEqual(Int(0), func(item Item, tree *LLRB) bool {
 		i++
 		if item.(Int) != Int(i) {
 			t.Errorf("bad order: got %d, expect %d", item.(Int), i)
@@ -63,7 +63,7 @@ func TestRange(t *testing.T) {
 		tree.ReplaceOrInsert(i)
 	}
 	k := 0
-	tree.AscendRange(String("ab"), String("ac"), func(item Item) bool {
+	tree.AscendRange(String("ab"), String("ac"), func(item Item, tree *LLRB) bool {
 		if k > 3 {
 			t.Fatalf("returned more items than expected")
 		}
@@ -85,7 +85,7 @@ func TestRandomInsertOrder(t *testing.T) {
 		tree.ReplaceOrInsert(Int(perm[i]))
 	}
 	j := 0
-	tree.AscendGreaterOrEqual(Int(0), func(item Item) bool {
+	tree.AscendGreaterOrEqual(Int(0), func(item Item, tree *LLRB) bool {
 		if item.(Int) != Int(j) {
 			t.Fatalf("bad order")
 		}
@@ -158,7 +158,7 @@ func TestRandomInsertPartialDeleteOrder(t *testing.T) {
 		tree.Delete(Int(i))
 	}
 	j := 0
-	tree.AscendGreaterOrEqual(Int(0), func(item Item) bool {
+	tree.AscendGreaterOrEqual(Int(0), func(item Item, tree *LLRB) bool {
 		switch j {
 		case 0:
 			if item.(Int) != Int(0) {
@@ -229,7 +229,7 @@ func TestInsertNoReplace(t *testing.T) {
 		}
 	}
 	j := 0
-	tree.AscendGreaterOrEqual(Int(0), func(item Item) bool {
+	tree.AscendGreaterOrEqual(Int(0), func(item Item, tree *LLRB) bool {
 		if item.(Int) != Int(j/2) {
 			t.Fatalf("bad order")
 		}


### PR DESCRIPTION
We may want do something(for example, delete the node when expiry) with the node
while iterating, so we need the reference of tree.

This patch also update the related test.

Signed-off-by: Hu Keping <hukeping@huawei.com>